### PR TITLE
Fix typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ libraries for all your tests creating the global fixture:
     # Run all tests with Asyncio/Trio only
     @pytest.fixture(params=['asyncio', 'trio'])
     def aiolib(request):
-        assert request.param
+        return request.param
 
 If you want to specify different options for the selected backend, you can do
 so by passing a tuple of (backend name, options dict):


### PR DESCRIPTION
Thanks for this project! I love how easy it is to use compared to `pytest-asyncio`.

This PR fixes a typo in the README where an assert should be a return statement, causing incorrect functionality.